### PR TITLE
Fixing command line `swift test` failure on both macOS / Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,6 @@ import PackageDescription
 let package = Package(
     name: "PerfectSession",
     dependencies: [
-		.Package(url: "https://github.com/PerfectlySoft/PerfectLib.git", majorVersion: 3),
-		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTP.git", majorVersion: 3),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTPServer.git", majorVersion: 3),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-Logger.git", majorVersion: 3),
 		.Package(url: "https://github.com/iamjono/SwiftString.git", majorVersion: 2),

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,8 @@ import PackageDescription
 let package = Package(
     name: "PerfectSession",
     dependencies: [
+		.Package(url: "https://github.com/PerfectlySoft/PerfectLib.git", majorVersion: 3),
+		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTP.git", majorVersion: 3),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-HTTPServer.git", majorVersion: 3),
 		.Package(url: "https://github.com/PerfectlySoft/Perfect-Logger.git", majorVersion: 3),
 		.Package(url: "https://github.com/iamjono/SwiftString.git", majorVersion: 2),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,6 @@
 import XCTest
-@testable import Perfect_SessionTests
+@testable import PerfectSessionTests
 
 XCTMain([
-     testCase(Perfect_SessionTests.allTests),
+     testCase(PerfectSessionTests.allTests),
 ])

--- a/Tests/PerfectSessionTests/PerfectSessionTests.swift
+++ b/Tests/PerfectSessionTests/PerfectSessionTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import PerfectSession
 
-class Perfect_SessionTests: XCTestCase {
+class PerfectSessionTests: XCTestCase {
 //    func testExample() {
 //        // This is an example of a functional test case.
 //        // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -27,7 +27,7 @@ class Perfect_SessionTests: XCTestCase {
 //	}
 
 
-    static var allTests : [(String, (Perfect_SessionTests) -> () throws -> Void)] {
+    static var allTests : [(String, (PerfectSessionTests) -> () throws -> Void)] {
         return [
 			("testValids", testValids),
 //			("testValidWithArray", testValidWithArray),


### PR DESCRIPTION
The test folder name mismatched with project name and caused trouble
like this:
```
Linking
./.build/x86_64-apple-macosx10.10/debug/PerfectSessionPackageTests.xctes
t/Contents/MacOS/PerfectSessionPackageTests
Undefined symbols for architecture x86_64:
"__T014PerfectSession12CSRFSecurityC7isValidSbSS6origin_SS4hosttFZ",
referenced from:
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu0_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu1_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu2_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu3_ in
Perfect_SessionTests.swift.o
"__T014PerfectSession12CSRFSecurityCMa", referenced from:
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu0_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu1_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu2_ in
Perfect_SessionTests.swift.o
__T020Perfect_SessionTestsAAC10testValidsyyFSbyKXKfu3_ in
Perfect_SessionTests.swift.o
ld: symbol(s) not found for architecture x86_64

```