### PR TITLE
Adding a flag for OAuth2

### DIFF
--- a/Sources/PerfectSession/PerfectSession.swift
+++ b/Sources/PerfectSession/PerfectSession.swift
@@ -53,7 +53,7 @@ public struct PerfectSession {
 	public var _state			= "recover"
 
 	/// Session state
-	public var _isOAuth2		= false
+	public var _isOAuth2		= SessionConfig.isOAuth2
 
 	/// When creating a new session, the "created" and "updated" properties are set
 	public init(){

--- a/Sources/PerfectSession/SessionConfig.swift
+++ b/Sources/PerfectSession/SessionConfig.swift
@@ -65,7 +65,8 @@ public struct SessionConfig {
 	/// The interval at which the system should purge stale session entries
 	public static var purgeInterval: Int = 3600 // default: once per hour
 
-
+	/// Specify if we want an OAuth2 behaviour
+	public static var isOAuth2 = false
 
 	/// CSRF Configuration
 	public struct CSRFconfig {


### PR DESCRIPTION
Configuring OAuth2 globally from `SessionConfig` instead of configuring from within each request's handler. 